### PR TITLE
Poprawic nawigacje issue 80

### DIFF
--- a/src/components/atoms/Menu.tsx
+++ b/src/components/atoms/Menu.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 type Props = { className?: string };
 const divStyles = {
-    transition: ' w-full h-22 relative -translate-y-11',
+    transition: ' w-full h-22 relative md:-translate-y-11 translate-y-22',
 };
 
 const DropMenu: React.FC<Props> = (props) => <div className={props.className}>{props.children}</div>;
@@ -53,7 +53,7 @@ export const Menu: React.FC = () => {
                         : ' transform ease-in duration-300 -translate-x-full'
                 }`}
             >
-                <div className={'translate-y-1/2'}>
+                <div className={'md:translate-y-1/2 overflow-y-scroll h-full md:h-auto'}>
                     {content.map(({ link, name }, i) => (
                         <DivMenu
                             className={`${divStyles.transition} ${

--- a/src/components/atoms/Menu.tsx
+++ b/src/components/atoms/Menu.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 type Props = { className?: string };
 const divStyles = {
-    transition: ' w-full h-22 relative md:-translate-y-11 translate-y-22',
+    transition: ' w-full h-22 relative md:translate-y-0 translate-y-22',
 };
 
 const DropMenu: React.FC<Props> = (props) => <div className={props.className}>{props.children}</div>;
@@ -53,7 +53,11 @@ export const Menu: React.FC = () => {
                         : ' transform ease-in duration-300 -translate-x-full'
                 }`}
             >
-                <div className={'md:translate-y-1/2 overflow-y-scroll h-full md:h-auto'}>
+                <div
+                    className={
+                        'md:translate-y-3/7 sm:translate-y-0 translate-y-22 overflow-y-scroll md:overflow-y-hidden h-full md:h-auto '
+                    }
+                >
                     {content.map(({ link, name }, i) => (
                         <DivMenu
                             className={`${divStyles.transition} ${

--- a/src/components/atoms/Menu.tsx
+++ b/src/components/atoms/Menu.tsx
@@ -11,7 +11,7 @@ const DropMenu: React.FC<Props> = (props) => <div className={props.className}>{p
 const DivMenu: React.FC<Props> = (props) => <div className={props.className}>{props.children}</div>;
 const DivLink: React.FC<{ link: string }> = ({ link, children }) => (
     <Link href={link}>
-        <div className="cursor-pointer text-center font-medium p-5 w-full h-full leading-10 hover:no-underline hover:bg-gray-800">
+        <div className="cursor-pointer text-center font-medium p-5 w-full h-full leading-10 hover:no-underline hover:bg-gray-800 hover:duration-500">
             {children}
         </div>
     </Link>

--- a/src/components/atoms/Menu.tsx
+++ b/src/components/atoms/Menu.tsx
@@ -4,14 +4,14 @@ import { useState } from 'react';
 
 type Props = { className?: string };
 const divStyles = {
-    transition: ' w-full h-20 relative',
+    transition: ' w-full h-22 relative',
 };
 
 const DropMenu: React.FC<Props> = (props) => <div className={props.className}>{props.children}</div>;
 const DivMenu: React.FC<Props> = (props) => <div className={props.className}>{props.children}</div>;
 const DivLink: React.FC<{ link: string }> = ({ link, children }) => (
     <Link href={link}>
-        <div className="cursor-pointer text-center block font-medium -mt-12 p-5 w-full h-full leading-10 hover:no-underline hover:bg-gray-800">
+        <div className="cursor-pointer text-center font-medium p-5 w-full h-full leading-10 hover:no-underline hover:bg-gray-800">
             {children}
         </div>
     </Link>
@@ -44,10 +44,10 @@ export const Menu: React.FC = () => {
     const [clicked, setClicked] = useState(false);
     const ToggleMenu = () => setClicked(!clicked);
     return (
-        <div className={'h-16 self-center'}>
+        <div>
             <MenuIcon clicked={clicked} click={ToggleMenu} />
             <DropMenu
-                className={`bg-gray-900 text-white flex flex-col items-center justify-center fixed  w-full h-full z-auto md:w-60 ${
+                className={`bg-gray-900 text-white fixed w-full h-full z-auto md:w-60 -translate-y-20 ${
                     clicked
                         ? 'transform duration-500 translate-x-0'
                         : ' transform ease-in duration-300 -translate-x-full'

--- a/src/components/atoms/Menu.tsx
+++ b/src/components/atoms/Menu.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 type Props = { className?: string };
 const divStyles = {
-    transition: ' w-full h-22 relative',
+    transition: ' w-full h-22 relative -translate-y-11',
 };
 
 const DropMenu: React.FC<Props> = (props) => <div className={props.className}>{props.children}</div>;
@@ -53,17 +53,19 @@ export const Menu: React.FC = () => {
                         : ' transform ease-in duration-300 -translate-x-full'
                 }`}
             >
-                {content.map(({ link, name }, i) => (
-                    <DivMenu
-                        className={`${divStyles.transition} ${
-                            clicked
-                                ? `transform ease-out duration-200 delay-${i * 150} translate-x-0`
-                                : 'transform ease-out -translate-x-full'
-                        }`}
-                    >
-                        <DivLink link={link}>{name}</DivLink>
-                    </DivMenu>
-                ))}
+                <div className={'translate-y-1/2'}>
+                    {content.map(({ link, name }, i) => (
+                        <DivMenu
+                            className={`${divStyles.transition} ${
+                                clicked
+                                    ? `transform ease-out duration-200 delay-${i * 150} translate-x-0`
+                                    : 'transform ease-out -translate-x-full'
+                            }`}
+                        >
+                            <DivLink link={link}>{name}</DivLink>
+                        </DivMenu>
+                    ))}
+                </div>
             </DropMenu>
         </div>
     );

--- a/src/components/atoms/MenuIcon.tsx
+++ b/src/components/atoms/MenuIcon.tsx
@@ -58,7 +58,9 @@ export const MenuIcon: React.FC<IconProps> = ({ clicked, click }) => {
         <Svg
             onClick={click}
             className={
-                clicked ? 'relative active cursor-pointer w-16 h-16 z-50 ' : 'relative cursor-pointer w-16 h-16 z-50 '
+                clicked
+                    ? 'relative active cursor-pointer w-16 ml-4 h-16 z-50 '
+                    : 'relative cursor-pointer w-16 ml-4 h-16 z-50 scale-125'
             }
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 200 200"

--- a/src/components/atoms/MenuIcon.tsx
+++ b/src/components/atoms/MenuIcon.tsx
@@ -57,11 +57,10 @@ export const MenuIcon: React.FC<IconProps> = ({ clicked, click }) => {
     return (
         <Svg
             onClick={click}
-            className={
-                clicked
-                    ? 'relative active cursor-pointer w-16 ml-4 h-16 z-50 '
-                    : 'relative cursor-pointer w-16 ml-4 h-16 z-50 scale-125'
-            }
+            className={`relative cursor-pointer w-16 ml-4 h-16 z-50 
+                ${clicked ? 'active' : 'scale-125'}
+
+            `}
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 200 200"
         >

--- a/src/components/atoms/Navigation.tsx
+++ b/src/components/atoms/Navigation.tsx
@@ -1,5 +1,4 @@
 import { Logo, Menu } from '@/src/components';
-import { useState } from 'react';
 
 export const Navigation: React.FC = () => {
     return (

--- a/src/components/atoms/Navigation.tsx
+++ b/src/components/atoms/Navigation.tsx
@@ -2,7 +2,7 @@ import { Logo, Menu } from '@/src/components';
 
 export const Navigation: React.FC = () => {
     return (
-        <div className="w-full bg-primaryBackgroundColor text-base max-h-22 h-22 z-50 sticky top-0 flex justify-between ">
+        <div className="w-full bg-primaryBackgroundColor text-base h-24 z-40 sticky top-0 flex justify-between items-center">
             <Menu />
             <Logo />
         </div>

--- a/src/components/molecules/Logo.tsx
+++ b/src/components/molecules/Logo.tsx
@@ -3,7 +3,7 @@ import { addImagePrefix } from '@/src/utils';
 export const Logo = () => {
     return (
         <img
-            className="mr-4"
+            className="mr-4 z-50"
             src={addImagePrefix('/images/full_logo1.svg')}
             width="168"
             height="50"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,6 +76,9 @@ module.exports = {
             backgroundSize: {
                 body: '91%',
             },
+            translate: {
+                '3/7': '42.8571429%',
+            },
             contrast: {
                 0: '0',
                 50: '.5',


### PR DESCRIPTION
Fixes #80 
 - usunięty flex, ale dalej wycentrowane względem całego okna witryny;
 - Menu zasłania granatowy bar nawigacyjny, ale nie obrazki;
 - hover:duration 500ms;
 - wycentrowane elementy w navigation, oraz usztywniony rozmiar do h-22;
 - useState dalej buguje się przy zmianie ręcznej szerokości rozdzielczości pomiędzy md i normal i wymaga załadowania ponownego strony
![image](https://user-images.githubusercontent.com/58345037/141208789-092ce421-1d75-4e90-9216-22547b49250d.png)
